### PR TITLE
Increasing size of groupslist column for large numbers of groups 

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -13,7 +13,7 @@
         <FIELD NAME="enrol_method" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="enrolment method"/>
         <FIELD NAME="profile_field" TYPE="int" LENGTH="3" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="profil field"/>
         <FIELD NAME="use_groupslist" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="use specific(s) group(s) only"/>
-        <FIELD NAME="groupslist" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Groups to use"/>
+        <FIELD NAME="groupslist" TYPE="char" LENGTH="2048" NOTNULL="false" SEQUENCE="false" COMMENT="Groups to use"/>
         <FIELD NAME="balises" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Balises for letters"/>
 
       </FIELDS>


### PR DESCRIPTION
Hi, we have a Moodle install with high enrollment courses and large numbers of groups for course discussions. This plugin has been extremely helpful but due to the number of groups, there's an error where some courses the list of groups is exceeding the column size. We've manually changed the size of the column in our database, but I'm proposing to increase this in the DB install as well.